### PR TITLE
Fetch products on Cart page reload

### DIFF
--- a/ecom-frontend/src/components/cart/Cart.jsx
+++ b/ecom-frontend/src/components/cart/Cart.jsx
@@ -4,12 +4,18 @@ import { Link } from "react-router-dom";
 import ItemContent from "./ItemContent";
 import CartEmpty from "./CartEmpty";
 import { formatPrice } from "../../utils/formatPrice";
+import { fetchProducts } from "../../store/actions/index.js";
+import { useEffect } from "react";
 
 const Cart = () => {
     const dispatch = useDispatch();
     const { cart } = useSelector((state) => state.carts);
     const newCart = { ...cart };
 
+    useEffect(() => {
+        dispatch(fetchProducts())
+    }, []);
+    
     newCart.totalPrice = cart?.reduce(
         (acc, cur) => acc + Number(cur?.specialPrice) * Number(cur?.quantity), 0
     );


### PR DESCRIPTION
When reloading the cart page the products disappear in the redux state. So changing the quantity doesn't work anymore, since it can't match products in the redux state anymore. It gives the error getState().products is null.

Also, if you used a filter on the product page, then only the filtered products would be in the redux state. If you added already products before you filtered, you also can't change the quantitiy of those.

Fetching the products fixes that issue